### PR TITLE
breaking: package only files required for wasm version

### DIFF
--- a/monero_utils/MyMoneroCoreBridge.js
+++ b/monero_utils/MyMoneroCoreBridge.js
@@ -99,60 +99,6 @@ module.exports = function(options)
 			});
 		} else { // this is synchronous so we can resolve immediately
 			console.log("Using wasm: ", false)
-			//
-			var scriptDirectory=""; // this was extracted from emscripten - it could get factored if anything else would ever need it
-			if (ENVIRONMENT_IS_NODE) {
-				scriptDirectory=__dirname+"/";
-			} else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
-				if (ENVIRONMENT_IS_WORKER) {
-					scriptDirectory = self.location.href
-				} else if (document.currentScript) {
-					scriptDirectory = document.currentScript.src
-				}
-				var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
-				if(_scriptDir){
-					scriptDirectory = _scriptDir
-				}
-				if (scriptDirectory.indexOf("blob:") !== 0) {
-					scriptDirectory = scriptDirectory.substr(0,scriptDirectory.lastIndexOf("/")+1)
-				} else {
-					scriptDirectory = ""
-				}
-			}
-			var read_fn;
-			if (ENVIRONMENT_IS_NODE) {
-				read_fn = function(filepath)
-				{
-					return require("fs").readFileSync(require("path").normalize(filepath)).toString()
-				};
-			} else if (ENVIRONMENT_IS_WEB||ENVIRONMENT_IS_WORKER) {
-				read_fn = function(url)
-				{ // it's an option to move this over to fetch, but, fetch requires a polyfill for these older browsers anyway - making fetch an automatic dep just for asmjs fallback - and the github/fetch polyfill does not appear to actually support mode (for 'same-origin' policy) anyway - probably not worth it yet 
-					var xhr = new XMLHttpRequest()
-					xhr.open("GET", url, false)
-					xhr.send(null)
-					//
-					return xhr.responseText
-				};
-			} else {
-				throw "Unsupported environment - please implement file reading for asmjs fallback case"
-			}
-			const filepath = locateFile("MyMoneroCoreCpp_ASMJS.asm.js", scriptDirectory)
-			const content = read_fn(filepath)
-			// TODO: verify content - for now, relying on same-origin and tls/ssl
-			var Module = {}
-			try {
-				eval(content) // I do not believe this is a safety concern, because content is server-controlled; https://humanwhocodes.com/blog/2013/06/25/eval-isnt-evil-just-misunderstood/
-			} catch (e) {
-				reject(e)
-				return
-			}
-			setTimeout(function()
-			{ // "delaying even 1ms is enough to allow compilation memory to be reclaimed"
-				Module_template['asm'] = Module['asm']
-				Module = null
-				resolve(new MyMoneroCoreBridgeClass(require("./MyMoneroCoreCpp_ASMJS")(Module_template)))
-			}, 1) 
-		}
+			throw new Error('ASMJS version has been removed in this fork')
 	});
 };

--- a/monero_utils/MyMoneroCoreBridge.js
+++ b/monero_utils/MyMoneroCoreBridge.js
@@ -100,5 +100,6 @@ module.exports = function(options)
 		} else { // this is synchronous so we can resolve immediately
 			console.log("Using wasm: ", false)
 			throw new Error('ASMJS version has been removed in this fork')
+    }
 	});
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,27 @@
     "webpack-cli": "3.1.0",
     "webpack-merge": "4.1.4"
   },
+  "files": [
+    "index.js",
+    "cryptonote_utils/biginteger.js",
+    "cryptonote_utils/moment.js",
+    "cryptonote_utils/money_format_utils.js",
+    "cryptonote_utils/nettype.js",
+    "hostAPI/response_parser_utils.js",
+    "monero_utils/monero_amount_format_utils.js",
+    "monero_utils/monero_config.js",
+    "monero_utils/monero_keyImage_cache_utils.js",
+    "monero_utils/monero_paymentID_utils.js",
+    "monero_utils/monero_sendingFunds_utils.js",
+    "monero_utils/monero_txParsing_utils.js",
+    "monero_utils/MyMoneroBridgeClass_Base.js",
+    "monero_utils/MyMoneroBridge_utils.js",
+    "monero_utils/MyMoneroCoreBridgeClass.js",
+    "monero_utils/MyMoneroCoreBridgeEssentialsClass.js",
+    "monero_utils/MyMoneroCoreBridge.js",
+    "monero_utils/MyMoneroCoreCpp_WASM.js",
+    "monero_utils/MyMoneroCoreCpp_WASM.wasm"
+  ],
   "jest": {
     "testEnvironment": "node",
     "verbose": true,


### PR DESCRIPTION
Excluded:
 * ASMJS variants from `monero_utils` (those are huge and should be unused),
 * `net_service_utils.js` from hostAPI,
 * `mnemonic_languages.js` from `cryptonote_utils`,
 * `src`, `tests`, all non-js non-wasm files.

Everything should just work.