### PR TITLE
Remove ASMJS build from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,11 +113,12 @@ set_target_properties(
 #
 #
 set (
-    EMCC_LINKER_FLAGS___BASE
+    EMCC_LINKER_FLAGS__WASM
     #unsure if the -I...boost..include is necessary here due to include above
     #
     "-Wall -std=c++11 \
---bind -s MODULARIZE=1 \
+--bind \
+-s MODULARIZE=1 \
 -s 'EXPORT_NAME=\"MyMoneroCoreCpp\"' \
 --llvm-lto 1 \
 -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
@@ -131,22 +132,17 @@ set (
 -s NO_DYNAMIC_EXECUTION=1 \
 -s NODEJS_CATCH_EXIT=0 \
 -s EXTRA_EXPORTED_RUNTIME_METHODS='[\"UTF8ToString\"]' \
+\
+-s WASM=1 \
+-Oz \
+-s ALLOW_MEMORY_GROWTH=1 \
+--post-js ${CMAKE_CURRENT_LIST_DIR}/src/module-post.js \
 "
     # • Disabling exception catching does not introduce silent failures 
     # • Probably don't need PRECISE_F32 but wouldn't want to not use it
     #
     #
     # -s SAFE_HEAP=1 \
-    # -g \
-)
-set(
-    EMCC_LINKER_FLAGS__WASM
-    "${EMCC_LINKER_FLAGS___BASE} \
--s WASM=1 \
--Oz \
--s ALLOW_MEMORY_GROWTH=1 \
---post-js ${CMAKE_CURRENT_LIST_DIR}/src/module-post.js \
-"
     # -g \
 )
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,6 @@ set (
     EMCC_LINKER_FLAGS___BASE
     #unsure if the -I...boost..include is necessary here due to include above
     #
-    # TODO? does EXPORT_NAME need to be the same for both targets? (or should it be set per-target with …_WASM, …_ASMJS?)
     "-Wall -std=c++11 \
 --bind -s MODULARIZE=1 \
 -s 'EXPORT_NAME=\"MyMoneroCoreCpp\"' \
@@ -141,22 +140,6 @@ set (
     # -g \
 )
 set(
-    EMCC_LINKER_FLAGS__ASMJS
-    "${EMCC_LINKER_FLAGS___BASE} \
--s WASM=0 \
--Os \
---separate-asm \
--s AGGRESSIVE_VARIABLE_ELIMINATION=1 \
--s ALLOW_MEMORY_GROWTH=0 \
---memory-init-file 0 \
--s SEPARATE_ASM_MODULE_NAME=asmjs \
-"
-    # --memory-init-file is explicitly set to 0 because optimization level is Oz, and some clients like React Native have trouble loading .mem files
-    # .... it also didn't seem to have a giant impact on perf. but this should be tested again
-    #
-    # --closure 1 \
-)
-set(
     EMCC_LINKER_FLAGS__WASM
     "${EMCC_LINKER_FLAGS___BASE} \
 -s WASM=1 \
@@ -171,16 +154,10 @@ set(
 #
 #
 message(STATUS "EMCC_LINKER_FLAGS__WASM ${EMCC_LINKER_FLAGS__WASM}")
-message(STATUS "EMCC_LINKER_FLAGS__ASMJS ${EMCC_LINKER_FLAGS__ASMJS}")
 #
 add_executable(MyMoneroCoreCpp_WASM ${SRC_FILES})
-add_executable(MyMoneroCoreCpp_ASMJS ${SRC_FILES})
 #
 set_target_properties(MyMoneroCoreCpp_WASM PROPERTIES LINK_FLAGS "${EMCC_LINKER_FLAGS__WASM}")
-set_target_properties(MyMoneroCoreCpp_ASMJS PROPERTIES LINK_FLAGS "${EMCC_LINKER_FLAGS__ASMJS}")
-#
-# set_target_properties(MyMoneroCoreCpp_WASM PROPERTIES SUFFIX ".html")
-# set_target_properties(MyMoneroCoreCpp_ASMJS PROPERTIES SUFFIX ".html")
 #
 # boost_atomic
 # boost_date_time
@@ -195,15 +172,6 @@ set_target_properties(MyMoneroCoreCpp_ASMJS PROPERTIES LINK_FLAGS "${EMCC_LINKER
 #
 target_link_libraries(
     MyMoneroCoreCpp_WASM
-    #
-    boost_chrono
-    boost_system
-    boost_thread
-    #
-    ${log-lib}
-)
-target_link_libraries(
-    MyMoneroCoreCpp_ASMJS
     #
     boost_chrono
     boost_system


### PR DESCRIPTION
#7 removed asmjs files from the package
#27 removed them from the repo and the build output

This PR prevents asmjs files from being built in the first place -- we don't package or use those.