### PR TITLE
Exclude NODEFS/IDBFS/WORKERFS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,8 @@ set (
 -Oz \
 -s ALLOW_MEMORY_GROWTH=1 \
 --post-js ${CMAKE_CURRENT_LIST_DIR}/src/module-post.js \
+\
+-s AUTO_JS_LIBRARIES=0 \
 "
     # • Disabling exception catching does not introduce silent failures 
     # • Probably don't need PRECISE_F32 but wouldn't want to not use it


### PR DESCRIPTION
Depends on #33 (`CMakeLists.txt` file conflicts).

This flag is undocumented afaik, but it solves the issue.

This removes `NODEFS`/`IDBFS`/`WORKERFS` from the generated js bundle, and leaves only `MEMFS` intact.
We don't need the ability to write to (or read from) the native or platform filesystem from the generated wasm binary, but we need the `/dev/urandom` API that `MEMFS` provides, so we can't just use `FILESYSTEM=0`.

An alternative would be to update emscripten from 1.38.48 to 1.39.x, where this behavior is the default.
Once we update, we can remove this flag.

Effective diff:
```diff
2327,2625c2327,2447
< 		var IDBFS = {
< 			...
< 		};
< 		var NODEFS = {
< 			...
< 		};
< 		var WORKERFS = {
< 			...
< 		};
4758,4763c3990
< 				FS.filesystems = {
< 					MEMFS: MEMFS,
< 					IDBFS: IDBFS,
< 					NODEFS: NODEFS,
< 					WORKERFS: WORKERFS,
< 				};
---
> 				FS.filesystems = { MEMFS: MEMFS };
7282,7286d6508
< 		if (ENVIRONMENT_HAS_NODE) {
< 			var fs = require("fs");
< 			var NODEJS_PATH = require("path");
< 			NODEFS.staticInit();
< 		}
```

Now, `ENVIRONMENT_HAS_NODE` is used only for `ENVIRONMENT_IS_NODE` detection, and no Node.js-specific code should run from inside Electron browser or worker even if Node.js integration is enabled.