### PR TITLE
build: create binaries via make instead of cmake

### DIFF
--- a/bin/build-emcpp.sh
+++ b/bin/build-emcpp.sh
@@ -4,5 +4,5 @@
 
 mkdir -p build &&
 cd build &&
-emconfigure cmake .. &&
+emcmake cmake .. &&
 emmake make -j `nproc`

--- a/bin/build-emcpp.sh
+++ b/bin/build-emcpp.sh
@@ -5,5 +5,4 @@
 mkdir -p build &&
 cd build &&
 emconfigure cmake .. &&
-emmake cmake --build . &&
-emmake make . -j `nproc`
+emmake make -j `nproc`

--- a/bin/build-emcpp.sh
+++ b/bin/build-emcpp.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-#EMCC_DEBUG=1 
+#EMCC_DEBUG=1
 
-mkdir -p build && 
-cd build && 
-emconfigure cmake .. && 
-emmake cmake --build . -j `nproc` && 
+mkdir -p build &&
+cd build &&
+emconfigure cmake .. &&
+emmake cmake --build . &&
 emmake make . -j `nproc`


### PR DESCRIPTION
This flag was added in `cmake 3.12`, but we are running `3.5.1` in Docker.