### PR TITLE
fix: change ignored tarball extension for boost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ tests/web/mymonero-core.js.map
 
 src/submodules/
 contrib/boost-sdk/
-boost_*.tgz
+boost_*.tar.gz


### PR DESCRIPTION
Our boost tarball is `tar.gz`.