### PR TITLE
build: replace -Oz with -Os

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ set (
 -s EXTRA_EXPORTED_RUNTIME_METHODS='[\"UTF8ToString\"]' \
 \
 -s WASM=1 \
--Oz \
+-Os \
 -s ALLOW_MEMORY_GROWTH=1 \
 --post-js ${CMAKE_CURRENT_LIST_DIR}/src/module-post.js \
 \


### PR DESCRIPTION
Increases wasm size by ~0.4%, insignificantly.

Ref: https://emscripten.org/docs/tools_reference/emcc.html

> `-Os`
> Like `-O3`, but focuses more on code size (and may make tradeoffs with speed). This can affect both wasm and JavaScript.

> `-Oz`
> Like `-Os`, but reduces code size even further, and may take longer to run. This can affect both wasm and JavaScript.

I haven't observed any performance benefit of this last time I tested, so not sure if we should do this.