### PR TITLE
feat: disable assertions to get deterministic JS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ set(
 -s 'EXPORT_NAME=\"MyMoneroCoreCpp\"' \
 --llvm-lto 1 \
 -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
--s ASSERTIONS=2 \
+-s ASSERTIONS=0 \
 -s EXIT_RUNTIME=0 \
 -s \"BINARYEN_TRAP_MODE='clamp'\" \
 -s PRECISE_F32=1 \


### PR DESCRIPTION
This disables assertions and strips debugging information from the resulting JS build. The JS build is deterministic after this change, but the wasm build isn't. I'm not sure if this change has any detrimental effects to debugging though. I don't think we should merge this until we get the wasm build deterministic because it might end up the case that we don't need this change. Pushing it up for reference for now.