### PR TITLE
feat: build docker-emscripten locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ tests/web/mymonero-core.js.map
 src/submodules/
 contrib/boost-sdk/
 boost_*.tar.gz
+
+docker-deps

--- a/README.exodus.md
+++ b/README.exodus.md
@@ -14,23 +14,9 @@ git pull
 ### 3. Build emscripten
 
 ```shell
-
-# Clean up old build files
-rm -rf build && mkdir build
-rm monero_utils/MyMoneroCoreCpp_*
-
-# Build boost emscripten
-docker run -it -v $(pwd):/app quay.io/exodusmovement/emscripten:3294ae562683 ./bin/build-boost-emscripten.sh
-
-# Build MyMonero emscripten
-docker run -it -v $(pwd):/app quay.io/exodusmovement/emscripten:3294ae562683 ./bin/archive-emcpp.sh
-
-# If you get '#error Including <emscripten/bind.h> requires building with -std=c++11 or newer!' error, re-run:
-
-docker run -it -v $(pwd):/app quay.io/exodusmovement/emscripten:3294ae562683 ./bin/archive-emcpp.sh
+./build.sh
 ```
 
 # Other Notes
 
-The `quay.io/exodusmovement/emscripten` image was built by Quay.io
-See instructions at https://github.com/ExodusMovement/docker-emscripten
+Emscripten is built in docker from https://github.com/ExodusMovement/docker-emscripten, but we build it locally as part of the build process in prepare.sh

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e # Exit on any error
+
+rm -rf build && mkdir build
+rm -f monero_utils/MyMoneroCoreCpp_*
+
+# Build boost emscripten - docker image is built locally in previous step
+echo "Building boost emscripten..."
+docker run -it -v $(pwd):/app local-registry.exodus.com/emscripten:latest ./bin/build-boost-emscripten.sh
+
+# Build MyMonero emscripten
+docker run -it -v $(pwd):/app local-registry.exodus.com/emscripten:latest ./bin/archive-emcpp.sh

--- a/prepare.sh
+++ b/prepare.sh
@@ -9,6 +9,8 @@ mymonero_core_cpp_url='https://github.com/ExodusMovement/mymonero-core-cpp'
 mymonero_core_cpp_hash='4f4a013ab3bad790c53cfdac6f8703d6f4935924'
 monero_core_custom_url='https://github.com/ExodusMovement/monero-core-custom'
 monero_core_custom_hash='7a9839da54995b25974a04f607855f7b4f748d5b'
+docker_emscripten_url='https://github.com/ExodusMovement/docker-emscripten'
+docker_emscripten_hash='510c4c4806a9ad1b04ceacf1005f633fd4ce7b04'
 
 ## Boost, hash should match upstream documented
 boost_url='https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz'
@@ -35,14 +37,13 @@ function clonerepo { # source, target, commit
 }
 
 # Clone dependencies
-
 echo "Cloning dependencies..."
 rm -rf 'src/submodules' && mkdir -p 'src/submodules'
 clonerepo "${mymonero_core_cpp_url}" 'src/submodules/mymonero-core-cpp' "${mymonero_core_cpp_hash}"
 clonerepo "${monero_core_custom_url}" 'src/submodules/mymonero-core-cpp/contrib/monero-core-custom' "${monero_core_custom_hash}"
+clonerepo "${docker_emscripten_url}" 'docker-deps/docker-emscripten' "${docker_emscripten_hash}"
 
 # Prepare boost source code
-
 echo "Downloading and validating boost..."
 if [[ ! -f "boost_1_69_0.tar.gz" ]]; then
   curl -LO "${boost_url}"
@@ -56,11 +57,14 @@ echo "Extracting boost..."
 rm -rf 'contrib/boost-sdk' && mkdir -p 'contrib/boost-sdk'
 tar zxf 'boost_1_69_0.tar.gz' -C 'contrib/boost-sdk' --strip-components=1
 
-# Prepare for build
-
-echo "Clearing the build dir..."
-rm -rf build && mkdir build
+# Build docker emscripten locally to avoid trusting the registry
+echo "Building Docker Emscripten..."
+cd docker-deps/docker-emscripten
+docker build \
+  --platform linux/amd64 \
+  -t local-registry.exodus.com/emscripten:latest \
+  .
+cd ../..
 
 # Finished
-
 echo "All done! We are prepared for the build now."


### PR DESCRIPTION
It seems risky to me to trust quay.io since our setup there isn't very locked down. This builds docker-emscripten locally as part of the deps. It also introduces a build.sh file for the build instead of the steps in the readme.